### PR TITLE
Fix default conversion to None if it is not specified.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge PurpleAir Sensor",
   "name": "homebridge-purpleair-sensor",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Monitor air quality using PurpleAir.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/SensorReading.test.ts
+++ b/src/SensorReading.test.ts
@@ -31,6 +31,11 @@ test('60m averages', () => {
   expect(reading.pm25).toBe(9.37);
 });
 
+test('default to no conversion', () => {
+  const reading = parsePurpleAirJson(testIndoorData);
+  expect(Math.round(reading.aqi)).toBe(29);
+});
+
 test('AQI excellent', () => {
   const reading = new SensorReading('1234', 6.86, NaN, 'None');
   expect(Math.round(reading.aqi)).toBe(29);

--- a/src/SensorReading.ts
+++ b/src/SensorReading.ts
@@ -1,6 +1,6 @@
 
 export function parsePurpleAirJson(data, averages?: string, conversion?: string) {
-  const conv = conversion ?? 'AQandU';
+  const conv = conversion ?? 'None';
   const pm25 = (() => {
     switch (averages) {
       case '10m': return JSON.parse(data.results[0].Stats).v1;
@@ -23,7 +23,7 @@ export class SensorReading {
    * @param sensor sensor station number (digits)
    * @param pm25 sensor pm 2.5 value (PM2_5Value)
    * @param voc sensor Voc value
-   * @param conversion conversion ("None", "AQandU", or "LRAPA")
+   * @param conversion conversion ("None", "AQandU", or "LRAPA"). Default to None.
    */
   constructor(
       public readonly sensor: string,
@@ -39,14 +39,14 @@ export class SensorReading {
 
   get aqi(): number {
     switch (this.conversion) {
-      case 'None' : {
-        return SensorReading.pmToAQI(this.pm25);
+      case 'AQandU' : {
+        return SensorReading.pmToAQandU(this.pm25);
       }
       case 'LRAPA': {
         return SensorReading.pmToLRAPA(this.pm25);
       }
-      default: { // "AQandU"
-        return SensorReading.pmToAQandU(this.pm25);
+      default: {
+        return SensorReading.pmToAQI(this.pm25);
       }
     }
   }


### PR DESCRIPTION
Changed the default conversion setting back to None, if the entry doesn't exist in the config file.