### PR TITLE
Only request fields that are actually used

### DIFF
--- a/src/accessory.ts
+++ b/src/accessory.ts
@@ -132,6 +132,7 @@ class PurpleAirSensor implements AccessoryPlugin {
       const request_config = {
         params: {
           read_key: this.key,
+          fields: 'humidity,voc,pm2.5,pm2.5_cf_1,pm2.5_10minute,pm2.5_30minute,pm2.5_60minute',
         },
       };
 


### PR DESCRIPTION
Since API charges per based on points, with fields requested increasing the cost, we now only request fields required for the plugin's core functionality.

Addresses Issue #47. 