### PR TITLE
Fix for VOC readings from local sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ sudo npm publish
 
 
 # Changelog
+- 3.0.1: Fixed fetching VOC for local sensors
 - 3.0.0: Major rewwrite to convert to the Platform plugin. Added humidity and temperatures reporting. Added ALT-CF3 conversion.
 - 2.1.0: Only fetch API fields needed for the core functionality of the plugin.
 - 2.0.2: Verbose network error logging.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": false,
   "displayName": "Homebridge PurpleAir Sensor",
   "name": "homebridge-purpleair-sensor",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Monitor air quality using PurpleAir.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/SensorReading.ts
+++ b/src/SensorReading.ts
@@ -29,7 +29,8 @@ function parseLocalPurpleAirJson(data, averages?: string, conversion?: string) {
   const humidity = parseFloat(data.current_humidity) + 4;
   const sensor = data.Id;
   const temperature = convertTemperatureToCelcius(parseFloat(data.current_temp_f));
-  return new SensorReading(sensor, pm25, pm25Cf1, humidity, temperature, null, conv, pm25alt);
+  const voc = data.gas_680 ? parseFloat(data.gas_680) : null;
+  return new SensorReading(sensor, pm25, pm25Cf1, humidity, temperature, voc, conv, pm25alt);
 }
 
 function getPM25(sensor_data, sensor_stats, averages) {


### PR DESCRIPTION
Local sensors use "gas_680" field for VOC readings, per the  [documentation](https://community.purpleair.com/t/local-json-documentation/6917).

Addresses https://github.com/jmkk/homebridge-purpleair-sensor/issues/64