### PR TITLE
Add Node.js 24 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/jmkk/homebridge-purpleair-sensor/issues"
   },
   "engines": {
-    "node": "^18 || ^20 || ^22",
+    "node": "^18 || ^20 || ^22 || ^24",
     "homebridge": "^1.6.0 || ^1.8.5 || ^2.0.0 || ^2.0.0-beta.23 || ^2.0.0-alpha.37"
   },
   "main": "dist/main.js",


### PR DESCRIPTION
Updates the engines field in package.json to support Node.js version 24, which has been tested and works correctly with this plugin.