### PR TITLE
Make sensor refresh interval configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ but with a few changes:
 2. Support private sensors.
 3. Support VOC sensor reading.
 4. Support different averages, from realtime data, all the way to 1 hour average.
-5. Sensor data gets refreshed every 5 minutes.
+5. Sensor data refresh interval is configurable (default 5 minutes).
 6. Allow reporting AQI value instead of PM2.5 density in HomeKit. The author is more used to reading AQI value,
    but HomeKit has only a field for PM2.5 density value. The plugin allows you to configure displaying AQI value
    in the density field.

--- a/config.schema.json
+++ b/config.schema.json
@@ -107,6 +107,14 @@
         "title": "Report AQI number instead of density (ug/m^3). HomeKit only allows reporting PM2.5 density instead of AQI value, but some prefer to see AQI value instead. If checked, the plugin will use the density field to report the AQI value.",
         "type": "boolean"
       },
+      "updateIntervalSecs": {
+        "title": "Sensor refresh interval in seconds",
+        "type": "integer",
+        "required": false,
+        "default": 300,
+        "minimum": 30,
+        "description": "How often to fetch new sensor readings. Increase this value to reduce PurpleAir API usage."
+      },
       "verboseLogging": {
         "title": "Verbose logging. If checked, log more information at info level, so you can see what's happening in homebridge log without running homebridge in debug mode.",
         "type": "boolean"

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -13,6 +13,7 @@ export class PurpleAirPlatformAccessory {
   private service: Service;
   private humidity?: Service;
   private temperature?: Service;
+  private readonly updateIntervalSecs: number;
 
   constructor(
     private readonly platform: PurpleAirPlatform,
@@ -83,8 +84,10 @@ export class PurpleAirPlatformAccessory {
       }
     }
 
-    const interval = DEFAULT_UPDATE_INTERVAL_SECS * 1000;
-    this.infoLog('Scheduling updates every ' + interval/1000/60 + ' minutes');
+    this.updateIntervalSecs = this.resolveUpdateIntervalSecs();
+    const interval = this.updateIntervalSecs * 1000;
+    const intervalMins = Number((this.updateIntervalSecs / 60).toFixed(2));
+    this.infoLog(`Scheduling updates every ${intervalMins} minutes`);
     setInterval(() => {
       this.update();
     }, interval);
@@ -102,6 +105,29 @@ export class PurpleAirPlatformAccessory {
 
   errorLog(message: string) {
     this.platform.log.error(this.accessory.displayName + ': ' + message);
+  }
+
+  resolveUpdateIntervalSecs() {
+    const configuredInterval = this.platform.config.updateIntervalSecs;
+    if (configuredInterval !== undefined) {
+      const intervalSeconds = Number(configuredInterval);
+      if (Number.isFinite(intervalSeconds)) {
+        if (intervalSeconds < MIN_UPDATE_INTERVAL_SECS) {
+          this.errorLog(
+            `Configured updateIntervalSecs ${intervalSeconds} is below minimum ${MIN_UPDATE_INTERVAL_SECS}; using minimum`,
+          );
+          return MIN_UPDATE_INTERVAL_SECS;
+        }
+
+        return intervalSeconds;
+      }
+
+      this.errorLog(
+        `Configured updateIntervalSecs ${configuredInterval} is invalid; using default ${DEFAULT_UPDATE_INTERVAL_SECS}`,
+      );
+    }
+
+    return DEFAULT_UPDATE_INTERVAL_SECS;
   }
 
   getAirQuality() {
@@ -260,7 +286,7 @@ export class PurpleAirPlatformAccessory {
 
     if (this.accessory.context.lastReading) {
       const lastUpdateDeltaMs = Date.now() - this.accessory.context.lastReading.updateTimeMs;
-      const updatesHappening = lastUpdateDeltaMs <= DEFAULT_UPDATE_INTERVAL_SECS * 1000;
+      const updatesHappening = lastUpdateDeltaMs <= this.updateIntervalSecs * 1000;
       if (updatesHappening) {
         activeResult = true;
       } else {


### PR DESCRIPTION
- add `updateIntervalSecs` to config schema (default 300, min 30)
- use configured interval for update scheduling and StatusActive checks
- keep scheduling log output in minutes for readability
- update README to reflect configurable refresh interval

Addresses https://github.com/jmkk/homebridge-purpleair-sensor/issues/79